### PR TITLE
fix: update component imports to use ui directory

### DIFF
--- a/frontend/src/components/molecules/Form/Form.tsx
+++ b/frontend/src/components/molecules/Form/Form.tsx
@@ -10,7 +10,7 @@ import {
   useFormContext,
 } from "react-hook-form"
 import { cn } from "@/lib/utils"
-import { Label } from "@/components/atoms/Label"
+import { Label } from "@/components/ui/label"
 
 const Form = FormProvider
 

--- a/frontend/src/components/molecules/Setup/Setup.tsx
+++ b/frontend/src/components/molecules/Setup/Setup.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Settings, Database, Cloud, Users, Key } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { UILD } from "@/lib/uild"
-import { Button } from "@/components/atoms/Button"
+import { Button } from "@/components/ui/button"
 
 interface SetupItem {
   title: string

--- a/frontend/src/components/molecules/UserNav/UserNav.tsx
+++ b/frontend/src/components/molecules/UserNav/UserNav.tsx
@@ -30,10 +30,10 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@/components/atoms/DropdownMenu"
+} from "@/components/ui/dropdown-menu"
 
-import { Button } from "@/components/atoms/Button"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/atoms/Avatar"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { UILD } from "@/lib/uild"
 
 interface UserNavProps {

--- a/frontend/src/components/organisms/Header/Header.tsx
+++ b/frontend/src/components/organisms/Header/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Search } from "lucide-react"
-import { Input } from "@/components/atoms/Input"
+import { Input } from "@/components/ui/input"
 import { UserNav } from "@/components/molecules/UserNav"
 import { MainNav } from "@/components/molecules/MainNav"
 import { UILD } from "@/lib/uild"

--- a/frontend/src/components/organisms/LoginForm/LoginForm.tsx
+++ b/frontend/src/components/organisms/LoginForm/LoginForm.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
-import { Button } from "@/components/atoms/Button"
-import { Input } from "@/components/atoms/Input"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import {
   Form,
   FormControl,


### PR DESCRIPTION
This PR updates component imports to use the new ui directory structure instead of the old atoms directory. This fixes the deployment issues caused by incorrect import paths.